### PR TITLE
Update shared.sh

### DIFF
--- a/lib/shared.sh
+++ b/lib/shared.sh
@@ -17,7 +17,7 @@ function vault_login() {
       -format=json \
       -method aws \
       role=${BUILDKITE_PLUGIN_VAULT_SECRETS_AUTH_ROLE} \
-      header_value="${VAULT_ADDR}" \
+      header_value="${BUILDKITE_PLUGIN_VAULT_SECRETS_VAULT_ADDR}" \
       )
   local login_rc=$?
   if [[ $login_rc -ne 0 ]]; then


### PR DESCRIPTION
## Background

This is a bugfix. Without it, the `header` parameter of the plugin is ignored.

## Changes

- Actually use the parametrised VAULT_ADDR

## How to test

Will be in the BK pipeline for [platform-infrastructure](https://github.com/PropellerAero/platform-infrastructure/)

## Release notes

see Changes